### PR TITLE
Choosing country name to match flag name

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@ layout: workshop
 root: .
 venue: Yonsei University
 address: 서울특별시 서대문구 연세로 50 연세대학교 상경대학
-country: Korea
+country: South-Korea
 language: kr
 latlng: 37.565784,126.93857200000002
 humandate: Jun 29-30, 2015


### PR DESCRIPTION
We need to use `South-Korea` as the country name to pick up the right flag on the main web site.
